### PR TITLE
Add --path flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,8 +10,16 @@ import (
 func main() {
 	var dirName = "node_modules"
 	var err error
+	var path string
+	var moduleDirPath string
+	flag.StringVar(&moduleDirPath, "path", "none", "File path to be used")
+	flag.Parse()
 
-	path := getPath()
+	if moduleDirPath == "none" {
+		path = getPath()
+	} else {
+		path = moduleDirPath
+	}
 
 	err = filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -27,6 +36,14 @@ func main() {
 	if err != nil {
 		fmt.Println(err)
 	}
+}
+
+func checkPath(path string) bool {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return false
+	}
+
+	return true
 }
 
 func getPath() string {


### PR DESCRIPTION
This allows the CLI to bypass prompting the user for a path. A user can specify where to clean up node modules, eg.
`go run main.go --path=path/to/node_modules`

And voila, all tidy!

![image](https://user-images.githubusercontent.com/7507990/66866631-a88d1900-ef67-11e9-9806-2e7ae4ed83f7.png)
